### PR TITLE
add npm package.json

### DIFF
--- a/index.styl
+++ b/index.styl
@@ -1,0 +1,1 @@
+@require 'normalize';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "normalize.styl",
+  "version": "3.0.3",
+  "description": "Stylus version of normalize.css",
+  "main": "normalize.styl",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bymathias/normalize.styl.git"
+  },
+  "keywords": [
+    "normalize",
+    "css",
+    "stylus"
+  ],
+  "author": ["Nicolas Gallagher", "Mathias Brouilly"],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bymathias/normalize.styl/issues"
+  },
+  "homepage": "https://github.com/bymathias/normalize.styl"
+}


### PR DESCRIPTION
A lot is moving towards  npm, away from bower. Even in our projects, normalize.styl seems the last bower package we cannot consume via NPM. I would like to change that.

In addition I added a index file which makes it possible to just reference the normalize.styl folder, without explizit reference to the file itself.